### PR TITLE
Update shipping text to 2 business days

### DIFF
--- a/client/pages/index/Reassurance.tsx
+++ b/client/pages/index/Reassurance.tsx
@@ -10,8 +10,8 @@ const iconMap : Record<string, React.FC<React.SVGProps<SVGSVGElement>>> = {
 };
 
 export function ProductReassurance() {
-	const features = [
-		{ icon: 'truck', text: "Expédition sous 24h" },
+        const features = [
+                { icon: 'truck', text: "Expédition sous 2 jours ouvrés" },
 		{ icon: 'shield', text: "Garantie 2 ans" },
 		{ icon: 'rotate-ccw', text: "Retour 30 jours" },
 		{ icon: 'lock', text: "Paiement sécurisé" }
@@ -37,7 +37,7 @@ export function FooterReassurance() {
 		{
 			icon: 'truck',
 			title: 'Livraison rapide',
-			text: 'Expédition sous 24h pour toutes les commandes'
+                        text: 'Expédition sous 2 jours ouvrés pour toutes les commandes'
 		},
 		{
 			icon: 'shield',

--- a/client/pages/order/+Page.tsx
+++ b/client/pages/order/+Page.tsx
@@ -274,7 +274,7 @@ export default function Page() {
 						</div>
 						<div className="flex items-center">
 							<Truck size={14} className="mr-1"/>
-							<span>Expédition sous 2 jours</span>
+                                                        <span>Expédition sous 2 jours ouvrés</span>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
## Summary
- update product reassurance to say "Expédition sous 2 jours ouvrés"
- update checkout page shipping note

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470d6a48b4832bb6f7c726be48877f